### PR TITLE
Note that the Chicken interpreter does not support FFI

### DIFF
--- a/ffi-c.adoc
+++ b/ffi-c.adoc
@@ -6,7 +6,7 @@ This is a guide to calling C code from Scheme.
 
 ### Compiler has FFI, interpreter does not
 
-(Are there Schemes like this?)
+Chicken, ...
 
 ### Compiler builds FFI stubs, interpreter can use them
 


### PR DESCRIPTION
Running code from `(chicken foreign)` with `csi` will produce an error stating that "the FFI is not supported in interpreted mode."