### PR TITLE
added rakefile to create 'www' folder, with guide files wrapped in sc…

### DIFF
--- a/esoterica.adoc
+++ b/esoterica.adoc
@@ -12,6 +12,7 @@ Scheme standards.
 
 This procedure works as expected:
 
+[source,scheme]
 -----
 (define (foo)
   (let ((x 1))
@@ -20,6 +21,7 @@ This procedure works as expected:
 
 Hoisting the `let` outside the `define`, the code no longer compiles:
 
+[source,scheme]
 -----
 (let ((x 1))
   (define (foo)
@@ -33,6 +35,7 @@ contain only definitions.
 Compare with `lambda` which does not deal with definitions, so
 hoisting a `let` over a `lambda` works fine:
 
+[source,scheme]
 -----
 (define foo
   (lambda ()
@@ -48,6 +51,7 @@ hoisting a `let` over a `lambda` works fine:
 Common Lisp does not support inner definitions, so hoisting a `let`
 over a definition works there:
 
+[source,scheme]
 -----
 (defun foo ()
   (let ((x 1))
@@ -78,6 +82,7 @@ literal type of its argument -- whether the argument a
 symbol/identifier, a literal string, a literal character, or a literal
 number:
 
+[source,scheme]
 -----
 (define-macro (typeof x)
   (cond
@@ -93,6 +98,7 @@ number:
 We can write a similar discriminator with syntax-case. The syntax-case
 macro system has "guards" specifically for that purpose:
 
+[source,scheme]
 -----
 (define-syntax typeof
   (lambda (x)
@@ -112,6 +118,7 @@ The latter example runs on Petite Chez Scheme.
 Syntax-rules can determine the literal type of some arguments: a pair, a
 vector, an empty list, a boolean:
 
+[source,scheme]
 -----
 (define-syntax typeof
   (syntax-rules ()
@@ -138,6 +145,7 @@ to kf if its argument is _anything_ other than a symbol. I believed
 such a macro symbol?? is impossible with syntax-rules -- until about a
 month ago I wrote it.
 
+[source,scheme]
 -----
 (define-syntax symbol??
   (syntax-rules ()
@@ -163,6 +171,7 @@ equivalence of identifiers. Both macros take two identifiers, and two
 continuations, kt and kf. The macros expand into kt if the two
 identifiers are equivalent. The macros expand into kf otherwise.
 
+[source,scheme]
 -----
 (define-syntax id-eq??
   (syntax-rules ()

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,0 +1,210 @@
+# Creates the doc.scheme.org page with formatted guide/ documentation
+# 
+# see rake -T for available options
+# Requires 'asciidoctor' and 'rouge' (source-highlighter) to be installed
+
+require 'asciidoctor'
+
+CWD = File.expand_path(File.dirname(__FILE__))
+SRC = File.join(CWD, '.')   # location of adoc files to include in guide
+
+#  - title to use is read direct from adoc file, 
+def get_page_title(page_name)
+  Asciidoctor.load_file(File.join(SRC, "#{page_name}.adoc")).doctitle
+end
+
+# Returns the html header using the given 'title' as the top-level <h1>
+# title.
+# 'page_title' flag is set to fale to suppress use of title head/title, for the index page.
+def header(title, page_title = true)
+  html_title = if page_title
+                 "Scheme Documentation: #{title}"
+               else
+                 "Scheme Documentation"
+               end
+  return <<END
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>#{html_title}</title>
+  <link rel="stylesheet" href="/schemeorg.css">
+  <link rel="stylesheet" href="/syntax.css">
+  <meta name="viewport" content=
+  "width=device-width, initial-scale=1">
+  <link rel="icon" href="/favicon/favicon.svg" sizes="any" type=
+  "image/svg+xml">
+</head>
+<body>
+  <header>
+    <ul class="menu">
+      <li>
+        <a href="https://www.scheme.org/">Home</a>
+      </li>
+      <li class="active">Docs</li>
+      <li>
+        <a href="https://community.scheme.org/">Community</a>
+      </li>
+      <li>
+        <a href="https://standards.scheme.org/">Standards</a>
+      </li>
+      <li>
+        <a href="https://get.scheme.org/">Implementations</a>
+      </li>
+    </ul>
+  </header>
+  <h1 id="logo">#{title}</h1>
+END
+end
+
+# Returns HTML footer
+def footer
+  return <<END
+<h2>Contributing</h2>
+  <section id="schemeorg-contributing" class="round-box green-box">
+    <p><kbd>doc.scheme.org</kbd> is a community subdomain of
+    <kbd>scheme.org</kbd>.</p>
+    <ul>
+      <li>Source code: <a href=
+      "https://github.com/schemedoc"><kbd class=
+      "github-org">schemedoc</kbd> organization</a> on GitHub.
+      </li>
+      <li>Discussion: <code class="mailing-list">schemedoc</code>
+      mailing list (<a href=
+      "https://srfi-email.schemers.org/schemedoc/">archives</a>,
+      <a href=
+      "https://srfi.schemers.org/srfi-list-subscribe.html#schemedoc">
+        subscribe</a>), GitHub issues.
+      </li>
+    </ul>
+  </section>
+</body>
+</html>
+END
+end
+
+# -----------------------------------------------------------------------------
+# Apply asciidoctor on every file in SRC to create the .html shells
+# If update? is true, then first checks if .adoc file is a new file or 
+# has newer time than its .html file, and only converts if so.
+def make_shells(update=false)
+  Dir.chdir(SRC) do
+    Dir.foreach('.') do |file|
+      next unless file.end_with? 'adoc'
+      if update
+        target = file.sub(/adoc\Z/, 'html')
+        if !File.exist?(target) or File.mtime(target) < File.mtime(file)
+          puts "Updating file: #{file}"
+          `asciidoctor -a source-highlighter=rouge -s #{file}`
+        end
+      else
+        puts "Converting file: #{file}"
+        `asciidoctor -a source-highlighter=rouge -s #{file}`
+      end
+    end
+  end
+end
+
+# Works through files in SRC and makes a complete HTML page in 'www'
+# attaching the header and footer.
+# Each page.html is placed into page/index.html for page/ links
+def make_pages() 
+  Dir.mkdir('www') unless Dir.exist?('www')
+  Dir.mkdir('www/guide') unless Dir.exist?('www/guide')
+  Dir.foreach(SRC) do |file|
+    next unless file.end_with? 'html'
+    puts "make page: #{file}"
+    page_name = file.gsub('.html', '')
+    page_dir = File.join('www', 'guide', page_name)
+    Dir.mkdir(page_dir) unless Dir.exist?(page_dir)
+
+    File.open(File.join(page_dir, 'index.html'), "w") do |site_file|
+      # output header
+      title = get_page_title(page_name)
+      site_file.puts header(title)
+
+      # output shell
+      IO.foreach(File.join(SRC, file)) do |line|
+        site_file.puts line
+      end
+      # output footer
+      site_file.puts footer
+    end
+  end
+end
+
+# Creates the index page for 'docs.scheme.org', with an automatically 
+# completed list of 'Scheme Guide' links
+def make_index_page
+  puts "make page: index.html"
+  File.open(File.join('www', 'guide', 'index.html'), "w") do |index_file|
+    # output header
+    index_file.puts header('Scheme Docs', false)
+
+    # Create Scheme Guide list
+    index_file.puts '<h2>Scheme Guide</h2>'
+    index_file.puts '<ul>'
+    Dir.foreach(SRC) do |file|
+      next unless file.end_with? 'html'
+      page_name = file.gsub('.html', '')
+      page_title = get_page_title(page_name)
+
+      index_file.puts "<li><a href=\"/guide/#{page_name}/\">#{page_title}</li>"
+    end
+    index_file.puts '</ul>'
+
+    # Output remaining links
+    index_file.puts <<END
+<h2>Scheme Requests for Implementation (SRFI)</h2>
+  <p><a href="srfi/library-names/">Library names</a></p>
+  <p><a href="srfi/support/">Support table</a></p>
+  <h2>More tools</h2>
+  <p><a href="//cookbook.scheme.org/" class=
+  "offsite">Cookbook</a></p>
+  <p><a href="//man.scheme.org/" class="offsite">Manual pages (Unix
+  style)</a></p>
+  <p><a href="surveys/">Surveys</a></p>
+END
+    # Output footer
+    index_file.puts footer
+  end
+end
+
+# Top-level function makes the entire website
+# - set update to true to only update changed pages
+def make_site(update=false)
+  make_shells(update)
+  make_pages
+  make_index_page
+end
+
+# -----------------------------------------------------------------------------
+# Tasks
+
+desc 'build web site afresh'
+task :build => [:clean] do
+  make_site
+  cp 'schemeorg.css', 'www'
+  cp 'syntax.css', 'www'
+end
+
+desc 'clean up directory'
+task :clean do
+  FileUtils.rm Dir.glob("#{SRC}/*.html"), force: true
+  FileUtils.rm_rf 'www'
+end
+
+desc 'show web www - port 8000'
+task :show do
+  Dir.chdir('www') do
+    `ruby -run -ehttpd . -p8000`
+  end
+end
+
+# update task
+# check time of .adoc vs .html and only convert if necessary
+desc 'update revised or new files only'
+task :update do
+  make_site true
+end
+

--- a/schemeorg.css
+++ b/schemeorg.css
@@ -1,0 +1,224 @@
+html {
+  font-family: sans-serif;
+  max-width: 45em;
+  margin: 1em;
+  background-color: beige;
+}
+
+p {
+  line-height: 1.4em;
+}
+
+h2 {
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+  color: darkred;
+  border-bottom: 1px solid red;
+}
+
+.round-box h2 {
+  color: black;
+  border-bottom: none;
+}
+
+sup {
+  line-height: 0;
+}
+
+img {
+  vertical-align: middle;
+}
+
+table {
+  margin-bottom: 20px;
+}
+
+th {
+  text-align: left;
+}
+
+th,
+td {
+  vertical-align: baseline;
+}
+
+table,
+th,
+td {
+  border: 1px solid black;
+}
+
+.no-border {
+  border: none;
+}
+
+table.no-border th,
+table.no-border td {
+  border: none;
+}
+
+.front-page-group table {
+  width: 100%;
+}
+
+h1#logo {
+  font-family: serif;
+  font-style: italic;
+  font-size: 5em;
+  margin-top: 0.3em;
+  margin-bottom: 0.3em;
+}
+
+a:link {
+  color: navy;
+}
+
+a:visited {
+  color: #551a8b;
+}
+
+a.offsite:link {
+  text-decoration: none;
+  border-bottom: 1px dashed navy;
+}
+
+a.offsite:visited {
+  text-decoration: none;
+  border-bottom: 1px dashed #551a8b;
+}
+
+.blog-posts li {
+  margin-left: -2rem;
+}
+
+.blog-posts ul {
+  list-style-type: none;
+}
+
+.blog-posts .more {
+  color: grey;
+  margin-left: 0.5rem;
+}
+
+.date {
+  color: grey;
+  font-size: 80%;
+}
+
+.sidenote {
+  text-align: right;
+}
+
+.blue-box {
+  background-color: lightblue;
+}
+
+.gray-box {
+  background-color: #ddc;
+}
+
+.green-box {
+  background-color: lightgreen;
+}
+
+.orange-box {
+  background-color: sandybrown;
+}
+
+.red-box {
+  background-color: pink;
+}
+
+.round-box {
+  border-radius: 15px;
+  padding: 3px 20px 3px 20px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.menu {
+  align-items: center;
+  border-bottom: 1px solid black;
+  columns: 2;
+  line-height: 2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.menu a {
+  margin: 0;
+  padding: 0;
+  text-decoration: none;
+}
+
+.menu li {
+  border-bottom: 5px solid transparent;
+  font-weight: bold;
+  font-size: 1.4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.menu li.active {
+  border-bottom: 5px solid black;
+  color: darkred;
+  width: max-content;
+}
+
+@media (min-width: 600px) {
+  .menu {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .menu li {
+    display: inline-block;
+  }
+}
+
+/* Syntax highlighting: */
+
+code.colorize span.default {
+  color: black;
+}
+
+code.colorize span.symbol {
+  color: blue;
+}
+
+code.colorize span.string {
+  color: green;
+}
+
+code.colorize span.character {
+  color: green;
+}
+
+code.colorize span.comment {
+  color: gray;
+}
+
+/* Monochromatic Color gradient from <https://www.colorhexa.com/ff0000> */
+code.colorize span.paren1 {
+  color: #b30000;
+}
+code.colorize span.paren2 {
+  color: #cc0000;
+}
+code.colorize span.paren3 {
+  color: #e60000;
+}
+code.colorize span.paren4 {
+  color: #ff0000;
+}
+code.colorize span.paren5 {
+  color: #ff1a1a;
+}
+code.colorize span.paren6 {
+  color: #ff3333;
+}
+code.colorize span.paren7 {
+  color: #ff4d4d;
+}
+

--- a/syntax.css
+++ b/syntax.css
@@ -1,0 +1,209 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight .cm {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cp {
+  color: #999999;
+  font-weight: bold;
+}
+.highlight .c1 {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+.highlight .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+.highlight .ge {
+  color: #000000;
+  font-style: italic;
+}
+.highlight .gr {
+  color: #aa0000;
+}
+.highlight .gh {
+  color: #999999;
+}
+.highlight .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+.highlight .go {
+  color: #888888;
+}
+.highlight .gp {
+  color: #555555;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .gu {
+  color: #aaaaaa;
+}
+.highlight .gt {
+  color: #aa0000;
+}
+.highlight .kc {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kd {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kn {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kp {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kr {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kt {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .k, .highlight .kv {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .mf {
+  color: #009999;
+}
+.highlight .mh {
+  color: #009999;
+}
+.highlight .il {
+  color: #009999;
+}
+.highlight .mi {
+  color: #009999;
+}
+.highlight .mo {
+  color: #009999;
+}
+.highlight .m, .highlight .mb, .highlight .mx {
+  color: #009999;
+}
+.highlight .sb {
+  color: #d14;
+}
+.highlight .sc {
+  color: #d14;
+}
+.highlight .sd {
+  color: #d14;
+}
+.highlight .s2 {
+  color: #d14;
+}
+.highlight .se {
+  color: #d14;
+}
+.highlight .sh {
+  color: #d14;
+}
+.highlight .si {
+  color: #d14;
+}
+.highlight .sx {
+  color: #d14;
+}
+.highlight .sr {
+  color: #009926;
+}
+.highlight .s1 {
+  color: #d14;
+}
+.highlight .ss {
+  color: #990073;
+}
+.highlight .s, .highlight .sa, .highlight .dl {
+  color: #d14;
+}
+.highlight .na {
+  color: #008080;
+}
+.highlight .bp {
+  color: #999999;
+}
+.highlight .nb {
+  color: #0086B3;
+}
+.highlight .nc {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .no {
+  color: #008080;
+}
+.highlight .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+.highlight .ni {
+  color: #800080;
+}
+.highlight .ne {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nf, .highlight .fm {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nl {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nn {
+  color: #555555;
+}
+.highlight .nt {
+  color: #000080;
+}
+.highlight .vc {
+  color: #008080;
+}
+.highlight .vg {
+  color: #008080;
+}
+.highlight .vi {
+  color: #008080;
+}
+.highlight .nv, .highlight .vm {
+  color: #008080;
+}
+.highlight .ow {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .o {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .w {
+  color: #bbbbbb;
+}
+.highlight {
+  background-color: #f8f8f8;
+}


### PR DESCRIPTION
…heme.org header/footer

This pull request adds a rakefile to convert all the .adoc guide files into html, including the scheme.org header/footer information around them, so they appear more integrated into the website.

Additionally, the rakefile calls asciidoctor with the rouge source-highlighter (also implemented in Ruby), which makes the source
code look prettier.

Note, css files added to make this self-contained, and esoterica.adoc has been edited to include syntax highlighting.